### PR TITLE
[DEV-7783] FIX: no dup link_error

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -240,9 +240,7 @@ class Signature(dict):
             new_options = self.options
 
         new_options = new_options if new_options else {}
-        new_options["link_error"] = (
-            new_options.get("link_error", []) + new_options.pop("link_error", [])
-        )
+        new_options["link_error"] = new_options.get("link_error", []) or []
 
         if self.immutable and not force:
             return (self.args, self.kwargs, new_options)


### PR DESCRIPTION
previously, link_error of [foo] became [foo, foo] - running the errback twice. Not sure what the original goal of this line of code was but I believe should have no effects